### PR TITLE
add param replace_select to extension

### DIFF
--- a/src/examples/zcl_zabap_tab_ed_ex1.clas.abap
+++ b/src/examples/zcl_zabap_tab_ed_ex1.clas.abap
@@ -111,7 +111,7 @@ CLASS zcl_zabap_tab_ed_ex1 IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_zabap_table_edit~replace_initial_data_select.
+  METHOD zif_zabap_table_edit~disable_default_select.
 
   ENDMETHOD.
 

--- a/src/screen/zabap_screen_with_containe.fugr.xml
+++ b/src/screen/zabap_screen_with_containe.fugr.xml
@@ -1206,6 +1206,12 @@
       <INT_NOTE>Many dynamic buttons on toolbar</INT_NOTE>
      </RSMPE_ATRT>
     </DOC>
+    <TIT>
+     <RSMPE_TITT>
+      <CODE>HEADER</CODE>
+      <TEXT>&amp;</TEXT>
+     </RSMPE_TITT>
+    </TIT>
    </CUA>
   </asx:values>
  </asx:abap>

--- a/src/zcl_zabap_table_edit.clas.abap
+++ b/src/zcl_zabap_table_edit.clas.abap
@@ -140,12 +140,14 @@ CLASS zcl_zabap_table_edit IMPLEMENTATION.
     CREATE DATA modified_data_ext TYPE HANDLE table.
 
     "---EXTENSION CALL---
-    extension->replace_initial_data_select( CHANGING initial_data = initial_data ).
+    DATA replace_select TYPE abap_bool.
+    extension->replace_initial_data_select( CHANGING replace_select = replace_select
+                                                     initial_data   = initial_data ).
 
     FIELD-SYMBOLS <initial_data> TYPE table.
     ASSIGN initial_data->* TO <initial_data>.
 
-    IF <initial_data> IS INITIAL.
+    IF replace_select = abap_false.
       SELECT * FROM (table_name) INTO TABLE @<initial_data>
       ORDER BY PRIMARY KEY.
     ENDIF.
@@ -171,8 +173,11 @@ CLASS zcl_zabap_table_edit IMPLEMENTATION.
     DATA(fc) = table_fields->get_fc_with_add_fields( additional_fields ).
 
     "---EXTENSION CALL---
-    extension->refresh_grid( EXPORTING in_edit_mode = in_edit_mode CHANGING field_catalogue = fc header_text = me->header_text
-        initial_data = initial_data modified_data_ext = modified_data_ext ).
+    extension->refresh_grid( EXPORTING in_edit_mode      = in_edit_mode
+                             CHANGING  field_catalogue   = fc
+                                       header_text       = me->header_text
+                                       initial_data      = initial_data
+                                       modified_data_ext = modified_data_ext ).
 
     DATA(field_cat) = CORRESPONDING lvc_t_fcat( fc ).
     grid->set_table_for_first_display( EXPORTING is_variant = VALUE #( report = table_name handle = 'BASE' username = sy-uname )
@@ -189,8 +194,13 @@ CLASS zcl_zabap_table_edit IMPLEMENTATION.
 
     comparator->update_mandant( modified_data_ext ).
     DATA(modified_data) = get_modified_data_no_ext( ).
-    comparator->compare_tables( EXPORTING initial_data = initial_data modified_data = modified_data
-       IMPORTING duplicates = duplicates inserted = inserted deleted = deleted before_modified = before_modified modified = modified ).
+    comparator->compare_tables( EXPORTING initial_data    = initial_data
+                                          modified_data   = modified_data
+                                IMPORTING duplicates      = duplicates
+                                          inserted        = inserted
+                                          deleted         = deleted
+                                          before_modified = before_modified
+                                          modified        = modified ).
 
     FIELD-SYMBOLS <duplicates>      TYPE table.
     ASSIGN duplicates->* TO <duplicates>.
@@ -202,15 +212,23 @@ CLASS zcl_zabap_table_edit IMPLEMENTATION.
     result = c_validation-ok.
 
     "---EXTENSION CALL---
-    extension->additional_validation( CHANGING result = result all_modified_data = modified_data
-                                               duplicates = duplicates inserted = inserted deleted = deleted
-                                               before_modified = before_modified modified = modified ).
+    extension->additional_validation( CHANGING result            = result
+                                               all_modified_data = modified_data
+                                               duplicates        = duplicates
+                                               inserted          = inserted
+                                               deleted           = deleted
+                                               before_modified   = before_modified
+                                               modified          = modified ).
   ENDMETHOD.
 
   METHOD command_save.
     TRY.
-        validate( IMPORTING result = DATA(result) duplicates = DATA(duplicates) inserted = DATA(inserted)
-                            deleted = DATA(deleted) before_modified = DATA(before_modified) modified = DATA(modified) ).
+        validate( IMPORTING result          = DATA(result)
+                            duplicates      = DATA(duplicates)
+                            inserted        = DATA(inserted)
+                            deleted         = DATA(deleted)
+                            before_modified = DATA(before_modified)
+                            modified        = DATA(modified) ).
 
         "Abort with message if data is invalid
         IF result = c_validation-incorrect_values.

--- a/src/zcl_zabap_table_edit.clas.abap
+++ b/src/zcl_zabap_table_edit.clas.abap
@@ -6,7 +6,7 @@ CLASS zcl_zabap_table_edit DEFINITION
   PUBLIC SECTION.
     METHODS:
       "! @parameter table_name | <p class="shorttext synchronized">Must be valid DDIC transparent table</p>
-      "! @parameter class_name | <p class="shorttext synchronized">Must implement ZIF_ZABAP_TABLE_EDIT interface or left empty</p>
+      "! @parameter extension_inst | <p class="shorttext synchronized">instance of a class implementing ZIF_ZABAP_TABLE_EDIT</p>
       "! @raising cx_sy_create_object_error | <p class="shorttext synchronized">If there is error when creating class of supplied name </p>
       constructor IMPORTING table_name TYPE string extension_inst TYPE REF TO zif_zabap_table_edit OPTIONAL header_text TYPE string DEFAULT '' RAISING cx_sy_create_object_error,
       set_change_doc_type IMPORTING change_doc_type TYPE zabap_change_doc_type,

--- a/src/zcl_zabap_table_edit.clas.abap
+++ b/src/zcl_zabap_table_edit.clas.abap
@@ -139,15 +139,11 @@ CLASS zcl_zabap_table_edit IMPLEMENTATION.
     table_fields->get_table_with_add_fields( EXPORTING additional_fields = additional_fields IMPORTING table = DATA(table) ).
     CREATE DATA modified_data_ext TYPE HANDLE table.
 
-    "---EXTENSION CALL---
-    DATA replace_select TYPE abap_bool.
-    extension->replace_initial_data_select( CHANGING replace_select = replace_select
-                                                     initial_data   = initial_data ).
-
     FIELD-SYMBOLS <initial_data> TYPE table.
     ASSIGN initial_data->* TO <initial_data>.
 
-    IF replace_select = abap_false.
+    "---EXTENSION CALL---
+    IF NOT extension->disable_default_select( ).
       SELECT * FROM (table_name) INTO TABLE @<initial_data>
       ORDER BY PRIMARY KEY.
     ENDIF.

--- a/src/zcl_zabap_table_edit_empty_if.clas.abap
+++ b/src/zcl_zabap_table_edit_empty_if.clas.abap
@@ -66,7 +66,7 @@ CLASS zcl_zabap_table_edit_empty_if IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_zabap_table_edit~replace_initial_data_select.
+  METHOD zif_zabap_table_edit~disable_default_select.
 
   ENDMETHOD.
 

--- a/src/zcl_zabap_table_edit_if_chain.clas.abap
+++ b/src/zcl_zabap_table_edit_if_chain.clas.abap
@@ -118,7 +118,7 @@ CLASS zcl_zabap_table_edit_if_chain IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_zabap_table_edit~replace_initial_data_select.
+  METHOD zif_zabap_table_edit~disable_default_select.
 
   ENDMETHOD.
 

--- a/src/zif_zabap_table_edit.intf.abap
+++ b/src/zif_zabap_table_edit.intf.abap
@@ -10,10 +10,12 @@ interface ZIF_ZABAP_TABLE_EDIT
 
   METHODS:
       "! <p class="shorttext synchronized">Display / table edit will be based on this data.</p>
+      "! @parameter replace_select | <p class="shorttext synchronized">if <> abap_true default select will be executed</p>
       "! @parameter initial_data | <p class="shorttext synchronized">Ref to table of given type with all data from table...</p>
-      "! All insert/deletion/modify will be executed in according to changes compared to this table
+      "! All insert/deletion/modify will be executed in according to changes compared to this table<br>
       "! can be used to replace the default db selection, similar to initial_data
-      replace_initial_data_select CHANGING initial_data TYPE REF TO data,
+      replace_initial_data_select CHANGING replace_select TYPE abap_bool DEFAULT abap_true
+                                           initial_data TYPE REF TO data,
       "! <p class="shorttext synchronized">Display / table edit will be based on this data.</p>
       "! @parameter initial_data | <p class="shorttext synchronized">Ref to table of given type with all data from table...</p>
       "! All insert/deletion/modify will be executed in according to changes compared to this table

--- a/src/zif_zabap_table_edit.intf.abap
+++ b/src/zif_zabap_table_edit.intf.abap
@@ -9,13 +9,10 @@ interface ZIF_ZABAP_TABLE_EDIT
     END OF c_validation.
 
   METHODS:
-      "! <p class="shorttext synchronized">Display / table edit will be based on this data.</p>
-      "! @parameter replace_select | <p class="shorttext synchronized">if <> abap_true default select will be executed</p>
-      "! @parameter initial_data | <p class="shorttext synchronized">Ref to table of given type with all data from table...</p>
-      "! All insert/deletion/modify will be executed in according to changes compared to this table<br>
-      "! can be used to replace the default db selection, similar to initial_data
-      replace_initial_data_select CHANGING replace_select TYPE abap_bool DEFAULT abap_true
-                                           initial_data TYPE REF TO data,
+      "! <p class="shorttext synchronized">disable default select</p>
+      "! @parameter disable_default_select | <p class="shorttext synchronized">if set to abap_true default select will not be executed</p>
+      "! disable default data selection (use initial_data to select data)
+      disable_default_select RETURNING VALUE(disable_default_select) type abap_bool,
       "! <p class="shorttext synchronized">Display / table edit will be based on this data.</p>
       "! @parameter initial_data | <p class="shorttext synchronized">Ref to table of given type with all data from table...</p>
       "! All insert/deletion/modify will be executed in according to changes compared to this table

--- a/src/zif_zabap_table_edit.intf.xml
+++ b/src/zif_zabap_table_edit.intf.xml
@@ -47,6 +47,11 @@
      <DESCRIPT>Called after setting up the screen - edit class...</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
+     <CMPNAME>DISABLE_DEFAULT_SELECT</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>disable default select</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
      <CMPNAME>GRID_SETUP</CMPNAME>
      <LANGU>E</LANGU>
      <DESCRIPT>Called once, e.g. modify commands / hook up other events</DESCRIPT>
@@ -70,11 +75,6 @@
      <CMPNAME>REFRESH_GRID</CMPNAME>
      <LANGU>E</LANGU>
      <DESCRIPT>Called whenever display mode is changed/refreshed, ...</DESCRIPT>
-    </SEOCOMPOTX>
-    <SEOCOMPOTX>
-     <CMPNAME>REPLACE_INITIAL_DATA_SELECT</CMPNAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>Display / table edit will be based on this data.</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CMPNAME>SET_EDIT_MODE</CMPNAME>
@@ -120,6 +120,12 @@
      <DESCRIPT>If called in edit mode</DESCRIPT>
     </SEOSUBCOTX>
     <SEOSUBCOTX>
+     <CMPNAME>DISABLE_DEFAULT_SELECT</CMPNAME>
+     <SCONAME>DISABLE_DEFAULT_SELECT</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>if set to abap_true default select will not be executed</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
      <CMPNAME>INITIAL_DATA</CMPNAME>
      <SCONAME>INITIAL_DATA</SCONAME>
      <LANGU>E</LANGU>
@@ -136,18 +142,6 @@
      <SCONAME>IN_EDIT_MODE</SCONAME>
      <LANGU>E</LANGU>
      <DESCRIPT>If called in edit mode</DESCRIPT>
-    </SEOSUBCOTX>
-    <SEOSUBCOTX>
-     <CMPNAME>REPLACE_INITIAL_DATA_SELECT</CMPNAME>
-     <SCONAME>INITIAL_DATA</SCONAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>Ref to table of given type with all data from table...</DESCRIPT>
-    </SEOSUBCOTX>
-    <SEOSUBCOTX>
-     <CMPNAME>REPLACE_INITIAL_DATA_SELECT</CMPNAME>
-     <SCONAME>REPLACE_SELECT</SCONAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>if &lt;&gt; abap_true default select will be executed</DESCRIPT>
     </SEOSUBCOTX>
    </DESCRIPTIONS_SUB>
   </asx:values>

--- a/src/zif_zabap_table_edit.intf.xml
+++ b/src/zif_zabap_table_edit.intf.xml
@@ -129,7 +129,7 @@
      <CMPNAME>REFRESH_GRID</CMPNAME>
      <SCONAME>INITIAL_DATA</SCONAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Ref to table of given type with all data from table...</DESCRIPT>
+     <DESCRIPT>Ref to table of given type with non-modified data</DESCRIPT>
     </SEOSUBCOTX>
     <SEOSUBCOTX>
      <CMPNAME>REFRESH_GRID</CMPNAME>
@@ -142,6 +142,12 @@
      <SCONAME>INITIAL_DATA</SCONAME>
      <LANGU>E</LANGU>
      <DESCRIPT>Ref to table of given type with all data from table...</DESCRIPT>
+    </SEOSUBCOTX>
+    <SEOSUBCOTX>
+     <CMPNAME>REPLACE_INITIAL_DATA_SELECT</CMPNAME>
+     <SCONAME>REPLACE_SELECT</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>if &lt;&gt; abap_true default select will be executed</DESCRIPT>
     </SEOSUBCOTX>
    </DESCRIPTIONS_SUB>
   </asx:values>


### PR DESCRIPTION
I noticed that replace_initial_data_select has a problem: If the select that is supposed to replace the default select does not return any data, the default select might be unwantedly executed.

I have added parameter replace_select, so that the extension can definitively decide, if the default select statement should be executed or not. 

I also accidentally executed pretty printer, which changed some formatting. Maybe add abaplint to this repo to enforce a formatting style or something.
Maybe abap cleaner can be added.